### PR TITLE
Fix zipping files for download

### DIFF
--- a/cherrymusicserver/ext/zipstream.py
+++ b/cherrymusicserver/ext/zipstream.py
@@ -310,7 +310,7 @@ class ZipStream:
             zinfo.compress_size = compress_size
         else:
             zinfo.compress_size = file_size
-        zinfo.CRC = CRC if CRC > 0 else CRC * -1
+        zinfo.CRC = abs(CRC)
         zinfo.file_size = file_size
         yield self.update_data_ptr(zinfo.DataDescriptor())
         self.filelist.append(zinfo)


### PR DESCRIPTION
Bug: https://github.com/devsnd/cherrymusic/issues/405
The integer out of range exception is thrown whenever a CRC is negative. Making the CRC positive fixes the problem.
