### PR TITLE
Change shebang to use /usr/bin/env python3

### DIFF
--- a/cherrymusic
+++ b/cherrymusic
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # CherryMusic - a standalone music server
 # Copyright (c) 2012 - 2014 Tom Wallroth & Tilman Boerner


### PR DESCRIPTION
Depending on the user's setup, python3 may not be in
/usr/bin, especially if they use something like
Homebrew, which uses /usr/local/bin. Using `env`
works around this, and is more likely to find a working
python3 installation.
