### PR TITLE
support chars that need encoding in playlist names when browsing

### DIFF
--- a/res/js/mediabrowser.js
+++ b/res/js/mediabrowser.js
@@ -322,6 +322,7 @@ MediaBrowser.static = {
             isowner: e.owner,
             candelete: e.owner || isAdmin,
             playlistlabel:e['title'],
+            encodedplaylistlabel:encodeURI(e['title']),
             username: e['username'],
             age: time2text(e['age']),
             username_color: userNameToColor(e.username),

--- a/res/templates/mediabrowser-playlist.html
+++ b/res/templates/mediabrowser-playlist.html
@@ -2,12 +2,12 @@
     <div class="playlist-browser-list-item-container">
         <div>
             <div class="playlist-detail-switch">
-                <a href="javascript:;" onclick="loadPlaylistContent({{playlistid}}, &quot;{{playlistlabel}}&quot;)">
+                <a href="javascript:;" onclick="loadPlaylistContent({{playlistid}}, decodeURI('{{encodedplaylistlabel}}'))">
                     <span class="glyphicon glyphicon-chevron-right"></span>
                 </a>
             </div>
             <div class="playlist-title">
-                <a href="javascript:;" onclick="loadPlaylist({{playlistid}}, &quot;{{playlistlabel}}&quot;)">
+                <a href="javascript:;" onclick="loadPlaylist({{playlistid}}, decodeURI('{{encodedplaylistlabel}}'))">
                     {{playlistlabel}}
                 </a>
             </div>
@@ -29,7 +29,7 @@
             {{#candelete}}
             <div class="playlist-deletebutton">
                 <a href="javascript:;" class="btn btn-xs btn-danger"
-                   onclick="confirmDeletePlaylist({{playlistid}}, &quot;{{playlistlabel}}&quot;)">&times;</a>
+                   onclick="confirmDeletePlaylist({{playlistid}}, decodeURI('{{encodedplaylistlabel}}'))">&times;</a>
             </div>
             {{/candelete}}
         </div>


### PR DESCRIPTION
To be able to both display and use the playlist name as a javascript param inside the templates, the title needs to be encoded and then decoded inside the quotes.

Another option could have been to modify the API to return an html-escaped title, but I wanted to keep it html-agnostic
