### PR TITLE
fix shuffle button update when adding tracks to playlist. Closes #399

### DIFF
--- a/res/js/playlistmanager.js
+++ b/res/js/playlistmanager.js
@@ -48,7 +48,11 @@ ManagedPlaylist.prototype = {
             }
         );
         self.jplayerplaylist._init();
-
+        // The following is a workaround to avoid jplayer to try to update the "shuffle" control
+        // This is needed because we are currently not using the "shuffle" option of jplayer
+        self.jplayerplaylist._updateControls = function() {
+            playlistManager.refreshCommands();
+        }
         $(self.playlistSelector+">ul.playlist-container-list").sortable({
             axis: "y",
             delay: 150,


### PR DESCRIPTION
The root problem is that the jplayer playlist is not being notified when "shuffle" is activated/deactivated. 
I couldn't just add that notification, because the jplayer version used in the project has a bug that makes the player fail when the "shuffle" flag is true (check res/js/ext/jplayer.playlist.js, lines 475 and 503, where "playRandomTrack" is invoked, without referencing "this")
