### PR TITLE
Fix displaying of duration when loading transcoded media

### DIFF
--- a/res/js/playlistmanager.js
+++ b/res/js/playlistmanager.js
@@ -667,10 +667,12 @@ PlaylistManager.prototype = {
         var self = this;
         var path = track.url;
         var title = track.title;
+        var duration = track.duration;
         var ext = getFileTypeByExt(path);
         var track = {
             title: title,
             wasPlayed : 0,
+            duration: duration,
         }
         var forced_bitrate = userOptions.media.force_transcode_to_bitrate;
         var formats = [];


### PR DESCRIPTION
When adding a transcoded music file (e.g. `*.flac`, `*.wav`) to the queue and start playing it, the duration on the bottom-right corner (part of jplayer) is always `00:00`. This only happen to transcoded music formats and doesn't happen to browser-supported formats like mp3 and ogg. I suppose this is because `transcodedURL()` doesn't copy the original `track`'s `duration` field to the new `track` object.
