### PR TITLE
Fix album alignment in safari, closes #501

### DIFF
--- a/res/bootstrap3/gen/cherrymusic.css
+++ b/res/bootstrap3/gen/cherrymusic.css
@@ -5220,6 +5220,7 @@ body:after {
   display: inline-block;
   width: 105px;
   height: 130px;
+  vertical-align: middle;
   overflow: hidden;
 }
 .list-dir-item-listview {

--- a/res/bootstrap3/less/mediabrowser.less
+++ b/res/bootstrap3/less/mediabrowser.less
@@ -127,6 +127,7 @@
         display: inline-block;
         width: @cover-view-item-width;
         height: @cover-view-item-height;
+        vertical-align: middle;
         overflow: hidden;
         
         &-listview {


### PR DESCRIPTION
The current album alignment in safari is sporadic and changes on each page refresh.