### PR TITLE
Clean up start sequence, migrations, albumart filenames

### DIFF
--- a/cherrymusic
+++ b/cherrymusic
@@ -147,30 +147,54 @@ else:
 parser.add_argument('--newconfig', dest='newconfig', action='store_true', help='Create a new config file next to your current one, e.g. ~/.config/cherrymusic/cherrymusic.conf.new.')
 parser.add_argument('--dropfiledb', dest='dropfiledb', action='store_true', help='Clear the file database. This might be necessary after a version jump.')
 parser.add_argument('--setup', dest='setup', action='store_true', help='Configure CherryMusic in your browser.')
-parser.add_argument('--adduser', dest='adduser', nargs=2, default=None, help='Create a new user with the given password.')
+parser.add_argument('--adduser', dest='adduser', nargs=2, metavar=('USERNAME', 'PASSWORD'), default=None, help='Create a new user with the given password.')
 
 ConfigOptions.addShortcutOption(parser, ('--port', '-p'), key='server.port', type=int, help='Set the port the server will listen to.')
 ConfigOptions.addGeneralOption(parser, ('--conf', '-c'), help='Override configuration values.')
 
 
 if __name__ == "__main__":
+    import sys
+
     args = parser.parse_args()
 
     if args.info:
         print(cherrymusicserver.info())
-        import sys
         sys.exit(0)
 
     if args.version:
         print(cherrymusicserver.version())
-        import sys
         sys.exit(0)
 
-    cherrymusicserver.CherryMusic(
-        update=args.update,
-        createNewConfig=args.newconfig,
-        dropfiledb=args.dropfiledb,
-        setup=args.setup,
-        cfg_override=ConfigOptions.configdict,
-        adduser=args.adduser,
-    )
+    if args.newconfig:
+        filepath = cherrymusicserver.pathprovider.configurationFile() + '.new'
+        cherrymusicserver.create_default_config_file(filepath)
+        sys.exit(0)
+
+    if args.setup:
+        args.update = args.update or ()
+        port = ConfigOptions.configdict.pop('server.port', False)
+        from cherrymusicserver import browsersetup
+        browsersetup.configureAndStartCherryPy(port) # blocks until config saved
+
+    cherrymusicserver.setup_config(ConfigOptions.configdict)
+    cherrymusicserver.setup_services()
+
+    if args.dropfiledb:
+        args.update = args.update or ()
+        filedb = cherrymusicserver.sqlitecache.DBNAME
+        cherrymusicserver.database.resetdb(filedb)
+
+    cherrymusicserver.migrate_databases()
+
+    if args.adduser:
+        username, password = args.adduser
+        success = cherrymusicserver.create_user(username, password)
+        sys.exit(0 if success else 1)
+
+    if args.update is not None:
+        cherrymusicserver.update_filedb(args.update)
+        if not args.setup:
+            sys.exit(0)
+
+    cherrymusicserver.start_server(ConfigOptions.configdict)

--- a/cherrymusic
+++ b/cherrymusic
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 # CherryMusic - a standalone music server
-# Copyright (c) 2012 - 2014 Tom Wallroth & Tilman Boerner
+# Copyright (c) 2012 - 2015 Tom Wallroth & Tilman Boerner
 #
 # Project page:
 #   http://fomori.org/cherrymusic/
@@ -29,8 +29,23 @@
 #
 
 import cmbootstrap
-cmbootstrap.bootstrap_and_migrate()
+cmbootstrap.bootstrap()
 import cherrymusicserver
+
+
+welcomeMessage = _("""
+==========================================================================
+Welcome to CherryMusic """ + cherrymusicserver.VERSION + """!
+
+To get this party started, you need to edit the configuration file, which
+resides under the following path:
+
+    """ + cherrymusicserver.pathprovider.configurationFile() + """
+
+Then you can start the server and listen to whatever you like.
+Have fun!
+==========================================================================
+""")
 
 
 class ConfigOptionsBase(object):
@@ -166,6 +181,8 @@ if __name__ == "__main__":
         print(cherrymusicserver.version())
         sys.exit(0)
 
+    cherrymusicserver.run_general_migrations()
+
     if args.newconfig:
         filepath = cherrymusicserver.pathprovider.configurationFile() + '.new'
         cherrymusicserver.create_default_config_file(filepath)
@@ -176,6 +193,12 @@ if __name__ == "__main__":
         port = ConfigOptions.configdict.pop('server.port', False)
         from cherrymusicserver import browsersetup
         browsersetup.configureAndStartCherryPy(port) # blocks until config saved
+
+    if not cherrymusicserver.pathprovider.configurationFileExists():
+        filepath = cherrymusicserver.pathprovider.configurationFile()
+        cherrymusicserver.create_default_config_file(filepath)
+        print(welcomeMessage)
+        exit(0)
 
     cherrymusicserver.setup_config(ConfigOptions.configdict)
     cherrymusicserver.setup_services()

--- a/cherrymusicserver/migrations/__init__.py
+++ b/cherrymusicserver/migrations/__init__.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # CherryMusic - a standalone music server
-# Copyright (c) 2012 - 2014 Tom Wallroth & Tilman Boerner
+# Copyright (c) 2012-2015 Tom Wallroth & Tilman Boerner
 #
 # Project page:
 #   http://fomori.org/cherrymusic/
@@ -28,4 +28,53 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 #
+""" Contains migrations of CherryMusic data; for database migrations, see
+    the database package.
 
+    A migration is a module named `migration_nnnn` , where `nnnn` is one of a
+    series of consecutive integers starting with `0001`.
+
+    A migration has a `do()` function which will be called to execute the
+    migration; the function is expected to decide whether the migration should
+    be carried out or not. If a migration requires manual intervention or needs
+    to be aborted for any reason, the function should print an actionable error
+    message and sys.exit with an error status.
+"""
+
+#python 2.6+ backward compability
+from __future__ import unicode_literals
+
+import os
+import pkgutil
+import re
+
+from backport import callable   # Py 3.0 and 3.1 compat
+
+
+_MIGRATIONS_PATH = os.path.dirname(__file__)
+_NAME_PATTERN = re.compile('^migration_\d{4}$')
+
+
+def check_and_migrate_all():
+    """ Runs all necessary migrations in alphabetical order.
+
+        The program can sys.exit if manual intervention is required.
+    """
+    for migration in load_migrations():
+        migration.do()
+
+
+def load_migrations():
+    """ Loads and returns all migration modules in alphabetical order """
+    itermods = pkgutil.iter_modules([_MIGRATIONS_PATH])
+    modnames = sorted(name for _, name, ispkg in itermods
+        if not ispkg and _NAME_PATTERN.match(name))
+    return [_import_migration(name) for name in modnames]
+
+
+def _import_migration(modulename):
+    qualname = 'cherrymusicserver.migrations.' + modulename
+    mig = __import__(qualname, fromlist='dummy')
+    if not callable(getattr(mig, 'do', None)):
+        raise TypeError('Migration needs a `do` function: ' + mig.__name__)
+    return mig

--- a/cherrymusicserver/migrations/migration_0001.py
+++ b/cherrymusicserver/migrations/migration_0001.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# CherryMusic - a standalone music server
+# Copyright (c) 2012-2015 Tom Wallroth & Tilman Boerner
+#
+# Project page:
+#   http://fomori.org/cherrymusic/
+# Sources on github:
+#   http://github.com/devsnd/cherrymusic/
+#
+# CherryMusic is based on
+#   jPlayer (GPL/MIT license) http://www.jplayer.org/
+#   CherryPy (BSD license) http://www.cherrypy.org/
+#
+# licensed under GNU GPL version 3 (or later)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+#
+"""Prompts for manual migration of CherryMusic config and data to XDG dirs
+
+See https://github.com/devsnd/cherrymusic/issues/224
+"""
+
+#python 2.6+ backward compability
+from __future__ import unicode_literals
+
+import os
+import sys
+
+from cherrymusicserver import pathprovider
+
+def do():
+    """If config file is still in old location, print a message and exit(1)"""
+    if pathprovider.configurationFileExists() or not pathprovider.fallbackPathInUse():
+        return
+    _printMigrationNotice()
+    sys.exit(1)
+
+
+def _printMigrationNotice():
+    print(_("""
+==========================================================================
+Oops!
+
+CherryMusic changed some file locations while you weren't looking.
+(To better comply with best practices, if you wanna know.)
+
+To continue, please move the following:
+
+$ mv {src} {tgt}""".format(
+        src=os.path.join(pathprovider.fallbackPath(), 'config'),
+        tgt=pathprovider.configurationFile()) + """
+
+$ mv {src} {tgt}""".format(
+        src=os.path.join(pathprovider.fallbackPath(), '*'),
+        tgt=pathprovider.getUserDataPath()) + """
+
+Thank you, and enjoy responsibly. :)
+==========================================================================
+"""))

--- a/cherrymusicserver/migrations/migration_0002.py
+++ b/cherrymusicserver/migrations/migration_0002.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*- #
+#
+# CherryMusic - a standalone music server
+# Copyright (c) 2012-2015 Tom Wallroth & Tilman Boerner
+#
+# Project page:
+#   http://fomori.org/cherrymusic/
+# Sources on github:
+#   http://github.com/devsnd/cherrymusic/
+#
+# CherryMusic is based on
+#   jPlayer (GPL/MIT license) http://www.jplayer.org/
+#   CherryPy (BSD license) http://www.cherrypy.org/
+#
+# licensed under GNU GPL version 3 (or later)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+#
+"""
+Moves cherrymusic.conf to correct location in OS X
+
+~/Application Support/cherrymusic => ~/Library/Application Support/cherrymusic
+
+See https://github.com/devsnd/cherrymusic/issues/459
+"""
+#python 2.6+ backward compability
+from __future__ import unicode_literals
+
+import os
+import shutil
+
+def do():
+    oldpath = os.path.join(os.path.expanduser('~'), 'Application Support', 'cherrymusic')
+    newpath = os.path.join(os.path.expanduser('~'), 'Library', 'Application Support', 'cherrymusic')
+    oldpath_exists = os.path.exists(oldpath)
+    newpath_exists = os.path.exists(newpath)
+    if oldpath_exists:
+        if newpath_exists:
+            # two data/conf directories, just warn and skip.
+            print("""There are two different data/config directories,
+but normally that shouldn't happen. The old and unused one is here:
+%s
+The currently used one is here:
+%s
+You can keep either one, and cherrymusic will figure it out on the next
+start.""" % (oldpath, newpath))
+        else:
+            # standard migration case. old one exists, but new one
+            # does not
+            print('UPDATE: Moving config/data directory to new location...')
+            shutil.move(oldpath, newpath)
+            print('UPDATE: done.')

--- a/cherrymusicserver/migrations/migration_0003.py
+++ b/cherrymusicserver/migrations/migration_0003.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*- #
+#
+# CherryMusic - a standalone music server
+# Copyright (c) 2012-2015 Tom Wallroth & Tilman Boerner
+#
+# Project page:
+#   http://fomori.org/cherrymusic/
+# Sources on github:
+#   http://github.com/devsnd/cherrymusic/
+#
+# CherryMusic is based on
+#   jPlayer (GPL/MIT license) http://www.jplayer.org/
+#   CherryPy (BSD license) http://www.cherrypy.org/
+#
+# licensed under GNU GPL version 3 (or later)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+#
+
+""" Migrate album art filenames from old base64 encoding to md5 hash """
+
+#python 2.6+ backward compability
+from __future__ import unicode_literals
+
+import base64
+import codecs
+import errno
+import logging
+import os
+import re
+import shutil
+import sys
+
+from cherrymusicserver import pathprovider
+
+log = logging.getLogger(__name__)
+
+_DONE_FILE = '.hashpath'
+_MIGRATION_SUFFIX = '-migrated'
+
+_ERR_MSG = """Error while migrating saved album art.
+
+Fix the cause of the error and restart to continue.
+
+Unmigrated files are in your album art folder:
+    {{artfolder}}
+Migrated files are in the migration folder:
+    {{artfolder}}{suffix}
+
+To abort the migration and lose the unmigrated album art:
+    - delete or move the album art folder;
+    - rename the migration folder by removing "{suffix}";
+    - create a file "{donefile}" in the folder (file can be empty).
+""".format(suffix=_MIGRATION_SUFFIX, donefile=_DONE_FILE)
+
+
+def do():
+    """ Migrate if necessary, exit(1) on error """
+    artfolder = pathprovider.albumArtFilePath('')
+    hashpathfile = os.path.join(artfolder, _DONE_FILE)
+    if os.path.exists(hashpathfile):
+        log.debug('Saved album art filenames already migrated. Skipping.')
+        return
+
+    try:
+        log.info('Migrating saved album art filenames...')
+        _migrate(artfolder)
+    except:
+        errmsg = _ERR_MSG.format(artfolder=artfolder)
+        log.exception('Error during album art migration')
+        log.critical(errmsg)
+        sys.exit(1)
+    else:
+        open(hashpathfile, 'a').close()
+        log.info('Album art filename migration done.')
+
+
+
+def _migrate(sourcedir):
+    """ migrate into different dir and then swap it in, to mitigate mishaps """
+    targetdir = sourcedir.rstrip(os.path.sep) + _MIGRATION_SUFFIX
+    try:
+        os.mkdir(targetdir)
+    except OSError as err:
+        # ignore if targetdir exists to allow restarting aborted migrations
+        if err.errno != errno.EEXIST:
+            raise
+
+    _base64_artfile_regex = re.compile(
+        '^'
+        '([\da-zA-Z+-]{4})*'             # pathprovider uses '-' instead of '\'
+        '([\da-zA-Z+-]{3}=|[\da-zA-Z+-]{2}==)?'
+        '$')
+    is_base64 = lambda s: bool(_base64_artfile_regex.match(s))
+
+    all_filenames = os.listdir(sourcedir)
+    migratable_filenames = (f for f in all_filenames if is_base64(f))
+    unmigratable_filenames = (f for f in all_filenames if not is_base64(f))
+
+    # move any non-albumart files first (which shouldn't exist, but who knows)
+    for filename in unmigratable_filenames:
+        oldpath = os.path.join(sourcedir, filename)
+        newpath = os.path.join(targetdir, filename)
+        _move_if_exists(oldpath, newpath)
+
+    # migrate albumart files
+    for filename in migratable_filenames:
+        ownerpath = _base64decode(filename)
+        oldpath = os.path.join(sourcedir, filename)
+        newname = os.path.basename(pathprovider.albumArtFilePath(ownerpath))
+        newpath = os.path.join(targetdir, newname)
+        _move_if_exists(oldpath, newpath)
+
+    os.rmdir(sourcedir)
+    os.rename(targetdir, sourcedir)
+
+def _move_if_exists(oldpath, newpath):
+    try:
+        shutil.move(oldpath, newpath)
+    except OSError as err:
+        # ignore errors from existing newpath and missing oldpath,
+        # which might occur if this migration is (concurrently) executed more
+        # than once by mistake
+        if err.errno not in (errno.EEXIST, errno.ENOENT):
+            raise
+
+def _base64decode(s):
+    """ decode old albumart base64 encoding; copied code from pathprovider """
+    utf8_bytestr = codecs.encode(s, 'UTF-8')
+    utf8_altchar = codecs.encode('+-', 'UTF-8')
+    return codecs.decode(base64.b64decode(utf8_bytestr, utf8_altchar), 'UTF-8')
+
+
+if __name__ == "__main__":   # pragma: no cover
+    do()

--- a/cherrymusicserver/migrations/test/test_migration_0003.py
+++ b/cherrymusicserver/migrations/test/test_migration_0003.py
@@ -1,0 +1,102 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+#
+# CherryMusic - a standalone music server
+# Copyright (c) 2012-2014 Tom Wallroth & Tilman Boerner
+#
+# Project page:
+#   http://fomori.org/cherrymusic/
+# Sources on github:
+#   http://github.com/devsnd/cherrymusic/
+#
+# CherryMusic is based on
+#   jPlayer (GPL/MIT license) http://www.jplayer.org/
+#   CherryPy (BSD license) http://www.cherrypy.org/
+#
+# licensed under GNU GPL version 3 (or later)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+#
+
+import nose
+
+from mock import *
+from nose.tools import *
+
+from cherrymusicserver.test import helpers
+
+import base64
+import codecs
+import hashlib
+import os
+
+from cherrymusicserver import pathprovider
+
+from cherrymusicserver.migrations import migration_0003
+
+
+def test_migration():
+    tests = [
+        ['empty dir',
+            [],
+            ['.hashpath']],
+        ['migrated dir',
+            ['.hashpath', _oldname('b/c')],
+            ['.hashpath', _oldname('b/c')]],
+        ['standard migration',
+            [_oldname('a'), _oldname('b/c')],
+            [_newname('a'), _newname('b/c'), '.hashpath']],
+        ['hidden file',
+            ['.foo', _oldname('b/c')],
+            ['.foo', _newname('b/c'), '.hashpath']],
+        ['invalid base64 encoding',
+            ['badbase64='],
+            ['badbase64=', '.hashpath']],
+    ]
+    for description, startnames, wantnames in tests:
+        check_filelist.description = 'migration_0003 (albumart): ' + description
+        yield check_filelist, startnames, wantnames
+
+
+def check_filelist(startnames, wantnames):
+    with helpers.tempdir('cherrymusic.test_migration_0003') as tmpd:
+        artfolder = helpers.mkpath('art/', tmpd)
+        for name in startnames:
+            helpers.mkpath(name, artfolder)
+
+        with patch('cherrymusicserver.pathprovider.albumArtFilePath', _mock_artpath(artfolder)):
+            migration_0003.do()
+
+        expected, result = sorted(wantnames), sorted(os.listdir(artfolder))
+        eq_(expected, result, '\n%r\n%r' % (expected, result))
+
+
+def _oldname(s):
+    "copied from pathprovider"
+    utf8_bytestr = codecs.encode(s, 'UTF-8')
+    utf8_altchar = codecs.encode('+-', 'UTF-8')
+    return codecs.decode(base64.b64encode(utf8_bytestr, utf8_altchar), 'UTF-8')
+
+def _newname(s):
+    utf8_bytestr = codecs.encode(s, 'UTF-8')
+    return hashlib.md5(utf8_bytestr).hexdigest() + '.thumb'
+
+_real_artpath = pathprovider.albumArtFilePath
+
+def _mock_artpath(tmpd):
+    return lambda s: os.path.join(tmpd, os.path.basename(_real_artpath(s)) if s else '')
+
+
+if __name__ == '__main__':
+    nose.runmodule()

--- a/cherrymusicserver/pathprovider.py
+++ b/cherrymusicserver/pathprovider.py
@@ -29,10 +29,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 #
 
+import codecs
+import hashlib
 import os
 import sys
-import base64
-import codecs
 
 userDataFolderName = 'cherrymusic'  # $XDG_DATA_HOME/userDataFolderName
 pidFileName = 'cherrymusic.pid'     # $XDG_DATA_HOME/userDataFolderName/cherrymusic.pid
@@ -122,18 +122,10 @@ def albumArtFilePath(directorypath):
     albumartcachepath = os.path.join(getUserDataPath(), 'albumart')
     if not os.path.exists(albumartcachepath):
         os.makedirs(albumartcachepath)
-    configpath = os.path.join(albumartcachepath, base64encode(directorypath))
-    return configpath
-
-def base64encode(s):
-    utf8_bytestr = codecs.encode(s, 'UTF-8')
-    utf8_altchar = codecs.encode('+-', 'UTF-8')
-    return codecs.decode(base64.b64encode(utf8_bytestr, utf8_altchar), 'UTF-8')
-
-def base64decode(s):
-    utf8_bytestr = codecs.encode(s, 'UTF-8')
-    utf8_altchar = codecs.encode('+-', 'UTF-8')
-    return codecs.decode(base64.b64decode(utf8_bytestr, utf8_altchar), 'UTF-8')
+    if directorypath:
+        filename = _md5_hash(directorypath) + '.thumb'
+        albumartcachepath = os.path.join(albumartcachepath, filename)
+    return albumartcachepath
 
 def assureFolderExists(folder,subfolders=['']):
     for subfolder in subfolders:
@@ -185,3 +177,7 @@ def stripext(filename):
     if '.' in filename:
         return filename[:filename.rindex('.')]
     return filename
+
+def _md5_hash(s):
+    utf8_bytestr = codecs.encode(s, 'UTF-8')
+    return hashlib.md5(utf8_bytestr).hexdigest()

--- a/cherrymusicserver/test/test_pathprovider.py
+++ b/cherrymusicserver/test/test_pathprovider.py
@@ -31,10 +31,11 @@
 
 import nose
 
-#from mock import *
+from mock import *
 from nose.tools import *
 
 import os.path
+import re
 
 from cherrymusicserver import log
 log.setTest()
@@ -48,27 +49,12 @@ def test_absOrConfigPath():
     eq_(abspath, pathprovider.absOrConfigPath(abspath))
 
 
-def test_base64coding():
-    """ base64encode and base64decode must satisfy `decode(encode(x)) == x` """
-    from base64 import b64encode
-    from functools import reduce
-    from backport import unichr  # py2 compat
-
-    # quick and dirty: list of strings that use whole base64 alphabet in utf-8
-    teststrings = [unichr(i) for i in range(2**12)]
-
-    # check if test set is complete
-    b64test = (b64encode(c.encode('utf-8')) for c in teststrings)
-    b64chars = reduce(set.union, b64test, set())
-    eq_(65, len(b64chars), "Whole base64 alphabet must be used in test set")
-
-    # check if encode and decode are inverse functions
-    encode = pathprovider.base64encode
-    decode = pathprovider.base64decode
-    for expected in teststrings:
-        transcoded = decode(encode(expected))
-        eq_(expected, transcoded)
-
+def test_albumArtFilePath():
+    """albumArtFilePath contains md5-filename, or no filename with empty argument"""
+    testpath = pathprovider.albumArtFilePath('a/s/d')
+    artfolder, filename = os.path.split(testpath)
+    ok_(re.match(r'^[0-9a-fA-F]{32}\.thumb$', filename), filename)
+    eq_(artfolder, pathprovider.albumArtFilePath('').rstrip(os.path.sep))
 
 if __name__ == '__main__':
     nose.runmodule()

--- a/cherrymusicserver/userdb.py
+++ b/cherrymusicserver/userdb.py
@@ -63,7 +63,7 @@ class UserDB:
             log.e('cannot create user "%s", already exists!' % user.name)
             return False
         self.conn.commit()
-        log.d('added user: ' + user.name)
+        log.i('added user: ' + user.name)
         return True
 
     def isDeletable(self, userid):

--- a/cmbootstrap/__init__.py
+++ b/cmbootstrap/__init__.py
@@ -1,3 +1,33 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# CherryMusic - a standalone music server
+# Copyright (c) 2012-2015 Tom Wallroth & Tilman Boerner
+#
+# Project page:
+#   http://fomori.org/cherrymusic/
+# Sources on github:
+#   http://github.com/devsnd/cherrymusic/
+#
+# CherryMusic is based on
+#   jPlayer (GPL/MIT license) http://www.jplayer.org/
+#   CherryPy (BSD license) http://www.cherrypy.org/
+#
+# licensed under GNU GPL version 3 (or later)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+#
 """
 This script is used to download cherrymusic dependencies on first startup.
 """
@@ -15,7 +45,7 @@ import os
 class DependencyInstaller:
     def __init__(self):
         self.cherrymusicfolder = os.path.dirname(os.path.dirname(__file__))
-        
+
     def install_cherrypy(self):
         """
         cherrypy releases: https://bitbucket.org/cherrypy/cherrypy/downloads
@@ -36,8 +66,8 @@ class DependencyInstaller:
         shutil.copytree(moduledir,os.path.join(self.cherrymusicfolder,'cherrypy'))
         print('Cleaning up temporary files...')
         shutil.rmtree(cherrypytempdir)
-        os.remove(cherrypytempfile)      
-    
+        os.remove(cherrypytempfile)
+
     def tmpdir(self, name):
         tempdirpath = os.path.join(tempfile.gettempdir(),name)
         if os.path.exists(tempdirpath):
@@ -49,61 +79,21 @@ class DependencyInstaller:
                 exit(1)
         os.mkdir(tempdirpath)
         return tempdirpath
-    
+
     def dl(self,url,target):
          with open(target, 'wb') as f:
             urlhandler = urllib.request.urlopen(urllib.request.Request(url))
             f.write(urlhandler.read())
 
-class Migrations(object):
-    """
-    This class contains all the workarounds required to make migrations
-    from older versions of cherrymusic to another possible. For database
-    migrations, please see the database/defs.
-    """
 
-    @classmethod
-    def check_and_perform_all(cls):
-        Migrations._osx_move_config_folder()
-
-    @classmethod
-    def _osx_move_config_folder(cls):
-        # See issue #459 cherrymusic.conf location on OS X on github.
-        # https://github.com/devsnd/cherrymusic/issues/459
-        #if not sys.platform.startswith('darwin'):
-        #    # only a osx bug
-        #    return
-        import os
-        import shutil
-        oldpath = os.path.join(os.path.expanduser('~'), 'Application Support', 'cherrymusic')
-        newpath = os.path.join(os.path.expanduser('~'), 'Library', 'Application Support', 'cherrymusic')
-        oldpath_exists = os.path.exists(oldpath)
-        newpath_exists = os.path.exists(newpath)
-        if oldpath_exists:
-            if newpath_exists:
-                # two data/conf directories, just warn and skip.
-                print("""There are two different data/config directories,
-but normally that shouldn't happen. The old and unused one is here:
-    %s
-The currently used one is here:
-    %s
-You can keep either one, and cherrymusic will figure it out on the next
-start.""" % (oldpath, newpath))
-            else:
-                # standard migration case. old one exists, but new one
-                # does not
-                print('UPDATE: Moving config/data directory to new location...')
-                shutil.move(oldpath, newpath)
-                print('UPDATE: done.')
-
-def bootstrap_and_migrate():
+def bootstrap():
     import sys
     try:
         import cherrypy
     except ImportError:
         print('''
-        CherryMusic needs the module "cherrypy" to run. You should install it 
-        using the package manager of your OS. Alternatively cherrymusic can 
+        CherryMusic needs the module "cherrypy" to run. You should install it
+        using the package manager of your OS. Alternatively cherrymusic can
         download it for you and put it in the folder in which currently
         CherryMusic resides.
         ''')
@@ -113,4 +103,3 @@ def bootstrap_and_migrate():
             print('Successfully installed cherrymusic dependencies! You can now start cherrymusic.')
         else:
             sys.exit(1)
-    Migrations.check_and_perform_all()


### PR DESCRIPTION
This is basically the fix for #509, plus a very simple + light mechanism to do migrations.

The latter pulls the migrations mechanism from `cmbootstrap` and replaces it with `cherrymusic.migrations`, a package which allows executing the `do()` functions of contained modules to carry out migrations.

I could not resist cleaning up the CherryMusic startup sequence while implementing this. It's gotten way more readable, makes dependencies more obvious and puts responsibilities where I think they belong. It's also easier now to set up a service and config environment without starting the server. 

The majority of the changes in this pull request come from this cleanup step; I suggest looking at the commits one by one if you want to get a better picture of what's going on.