### PR TITLE
Patch to make clear also stop playback and clear interface

### DIFF
--- a/cherrymusicserver/__init__.py
+++ b/cherrymusicserver/__init__.py
@@ -551,8 +551,6 @@ def _get_version_from_git():
     if os.path.exists('.git') == False:
 	return None
     config = update_config()
-    if config['general.get_version_from_git'] == False:
-        return None
     def fetch(cmdname):
         import re
         from subprocess import Popen, PIPE

--- a/cherrymusicserver/__init__.py
+++ b/cherrymusicserver/__init__.py
@@ -209,9 +209,11 @@ def update_config():
         See :mod:`~cherrymusicserver.configuration`.
     """
     defaults = cfg.from_defaults()
-    filecfg = cfg.from_configparser(pathprovider.configurationFile())
-    _notify_about_config_updates(defaults, filecfg)
+    configfile = pathprovider.configurationFile()
+    if configfile is not None:
+        filecfg = cfg.from_configparser(pathprovider.configurationFile())
     if filecfg is not None:
+        _notify_about_config_updates(defaults, filecfg)
         return defaults.replace(filecfg, on_error=log.e)
     else:
         return defaults

--- a/cherrymusicserver/__init__.py
+++ b/cherrymusicserver/__init__.py
@@ -549,7 +549,7 @@ def _get_version_from_git():
         or None if not possible.
     """
     if os.path.exists('.git') == False:
-	return None
+        return None
     config = update_config()
     def fetch(cmdname):
         import re
@@ -566,7 +566,7 @@ def _get_version_from_git():
             try:
                 devnull = open(os.devnull, 'w')
                 p = Popen(cmd[cmdname], stdout=PIPE, stderr=devnull)
-	        out, err = p.communicate()
+                out, err = p.communicate()
             except:
                 return None
             finally:

--- a/cherrymusicserver/__init__.py
+++ b/cherrymusicserver/__init__.py
@@ -546,6 +546,8 @@ def _get_version_from_git():
     """ Returns more precise version string based on the current git HEAD,
         or None if not possible.
     """
+    if os.path.exists('.git') == False:
+	return None
     config = update_config()
     if config['general.get_version_from_git'] == False:
         return None

--- a/cherrymusicserver/__init__.py
+++ b/cherrymusicserver/__init__.py
@@ -210,7 +210,10 @@ def update_config():
     """
     defaults = cfg.from_defaults()
     filecfg = cfg.from_configparser(pathprovider.configurationFile())
-    return defaults.replace(filecfg, on_error=log.e)
+    if filecfg is not None:
+        return defaults.replace(filecfg, on_error=log.e)
+    else:
+        return defaults
 
 def setup_config(override_dict=None):
     """ Updates the internal configuration using the following hierarchy:

--- a/cherrymusicserver/__init__.py
+++ b/cherrymusicserver/__init__.py
@@ -202,6 +202,15 @@ def setup_services():
         'connargs': {'check_same_thread': False},
     })
 
+def update_config():
+    """ Updates the internal configuration using the following hierarchy:
+        file_config > default_config
+
+        See :mod:`~cherrymusicserver.configuration`.
+    """
+    defaults = cfg.from_defaults()
+    filecfg = cfg.from_configparser(pathprovider.configurationFile())
+    return defaults.replace(filecfg, on_error=log.e)
 
 def setup_config(override_dict=None):
     """ Updates the internal configuration using the following hierarchy:
@@ -211,9 +220,7 @@ def setup_config(override_dict=None):
 
         See :mod:`~cherrymusicserver.configuration`.
     """
-    defaults = cfg.from_defaults()
-    filecfg = cfg.from_configparser(pathprovider.configurationFile())
-    custom = defaults.replace(filecfg, on_error=log.e)
+    custom = update_config()
     if override_dict:
         custom = custom.replace(override_dict, on_error=log.e)
     global config
@@ -536,6 +543,9 @@ def _get_version_from_git():
     """ Returns more precise version string based on the current git HEAD,
         or None if not possible.
     """
+    config = update_config()
+    if config['general.get_version_from_git'] == False:
+        return None
     import re
     from subprocess import Popen, PIPE
     cmd = {

--- a/cherrymusicserver/__init__.py
+++ b/cherrymusicserver/__init__.py
@@ -210,6 +210,7 @@ def update_config():
     """
     defaults = cfg.from_defaults()
     filecfg = cfg.from_configparser(pathprovider.configurationFile())
+    _notify_about_config_updates(defaults, filecfg)
     if filecfg is not None:
         return defaults.replace(filecfg, on_error=log.e)
     else:
@@ -228,7 +229,6 @@ def setup_config(override_dict=None):
         custom = custom.replace(override_dict, on_error=log.e)
     global config
     config = custom
-    _notify_about_config_updates(defaults, filecfg)
 
 
 def run_general_migrations():

--- a/cherrymusicserver/configuration.py
+++ b/cherrymusicserver/configuration.py
@@ -266,6 +266,14 @@ def from_defaults():
                     Notify admins about available security and feature updates.
                             ''')
 
+    with c['general.get_version_from_git'] as get_version_from_git:
+        get_version_from_git.value = True
+        # i18n: Don't mind whitespace - string will be re-wrapped automatically. Use blank lines to separate paragraphs.
+        get_version_from_git.doc = _('''
+                    Get a more precise version string based on the current git HEAD.
+                            ''')
+
+
     return c.to_configuration()
 
 

--- a/cherrymusicserver/configuration.py
+++ b/cherrymusicserver/configuration.py
@@ -266,13 +266,6 @@ def from_defaults():
                     Notify admins about available security and feature updates.
                             ''')
 
-    with c['general.get_version_from_git'] as get_version_from_git:
-        get_version_from_git.value = True
-        # i18n: Don't mind whitespace - string will be re-wrapped automatically. Use blank lines to separate paragraphs.
-        get_version_from_git.doc = _('''
-                    Get a more precise version string based on the current git HEAD.
-                            ''')
-
 
     return c.to_configuration()
 

--- a/doc/man/cherrymusic.conf.5
+++ b/doc/man/cherrymusic.conf.5
@@ -86,6 +86,9 @@ This is the path to the SSL key that CherryMusic will use for SSL encryption. To
 .IP "\fB    update_notification = True | False\fP"
 If enabled, admins are notified about available security and feature updates when logging on in the web interface.
 
+.IP "\fB    get_version_from_git = True | False\fP"
+If enabled, attempts to get a more precise version string based on the current git HEAD
+
 .SH "FILES"
 According to XDG Base Directory Specification, CherryMusic honors $XDG_CONFIG_HOME. If this variable is empty or not set, the configuration file is stored using the standard path:
 

--- a/doc/man/cherrymusic.conf.5
+++ b/doc/man/cherrymusic.conf.5
@@ -86,9 +86,6 @@ This is the path to the SSL key that CherryMusic will use for SSL encryption. To
 .IP "\fB    update_notification = True | False\fP"
 If enabled, admins are notified about available security and feature updates when logging on in the web interface.
 
-.IP "\fB    get_version_from_git = True | False\fP"
-If enabled, attempts to get a more precise version string based on the current git HEAD
-
 .SH "FILES"
 According to XDG Base Directory Specification, CherryMusic honors $XDG_CONFIG_HOME. If this variable is empty or not set, the configuration file is stored using the standard path:
 

--- a/res/js/playlistmanager.js
+++ b/res/js/playlistmanager.js
@@ -671,7 +671,7 @@ PlaylistManager.prototype = {
         return false;
     },
     clearQueue : function(){
-      this.cmd_stop();
+      $(this.cssSelectorjPlayer).jPlayer("clearMedia");
       this.managedPlaylists[0].jplayerplaylist.remove();
       this.refreshCommands();
       $(this).blur();

--- a/res/js/playlistmanager.js
+++ b/res/js/playlistmanager.js
@@ -671,6 +671,7 @@ PlaylistManager.prototype = {
         return false;
     },
     clearQueue : function(){
+      this.cmd_stop();
       this.managedPlaylists[0].jplayerplaylist.remove();
       this.refreshCommands();
       $(this).blur();


### PR DESCRIPTION
Hello,

Pressing \clear' currently only clears the play list, where I'd expected it to also stop playback.

I started by adding a call to cmd_stop in clearQueue, which stopped playback but left the title of the page and player unchanged. Both page and player kept displaying the title of the song, the player also kept displaying the length of the song.

Digging through the code and documentation I found the following solution to make pressing 'clear' work as I'd expected.

Mazzel,

Martijn.