### PR TITLE
Predictable local albumart selection

### DIFF
--- a/cherrymusicserver/albumartfetcher.py
+++ b/cherrymusicserver/albumartfetcher.py
@@ -196,7 +196,7 @@ class AlbumArtFetcher:
 
         filetypes = (".jpg", ".jpeg", ".png")
         try:
-            for file_in_dir in os.listdir(path):
+            for file_in_dir in sorted(os.listdir(path)):
                 if not file_in_dir.lower().endswith(filetypes):
                     continue
                 try:


### PR DESCRIPTION
In my music directory are multiple album directories, and each album directory contains a cover image (01.png) and a back cover image (02.png), visualized as following:

```
musicroot
├── album01
│   ├── 01.png
│   └── 02.png
├── album02
│   ├── 01.png
│   └── 02.png
└── album03
    ...
```

For some directories the cover image (01.png) is selected as the local albumart, while for other directories the back cover image (02.png) is selected instead. This is because CherryMusic selects the first image file returned by `os.listdir()` as the local albumart, but the order of filenames returned by `os.listdir()` is unpredictable (see the [python documentation](https://docs.python.org/3/library/os.html#os.listdir)).

By sorting the list returned by `os.listdir()`, the first image file (in alphabetical order) will always be selected.
