### PR TITLE
Preferring ffmpeg/avconv over faad for m4a files as

### DIFF
--- a/audiotranscode/__init__.py
+++ b/audiotranscode/__init__.py
@@ -190,7 +190,16 @@ class AudioTranscode:
                         '-acodec', 'pcm_s16le', '-']),
         Decoder('flac', ['flac', '-F', '-d', '-c', 'INPUT']),
         Decoder('aac', ['faad', '-w', 'INPUT']),
-        Decoder('m4a', ['faad', '-w', 'INPUT']),
+
+        #Preferring ffmpeg/avconv over faad for m4a files as Apple Lossless (ALAC)
+        #files carry the m4a extension as well.  While ffad does not handle ALAC 
+        #it seems ffmpeg does at least on Raspbian/Ubuntu. 
+        #Syntax copied from the wma declaration above.
+        #Decoder('m4a', ['faad', '-w', 'INPUT']), 
+        Decoder('m4a'  , ['ffmpeg', '-ss', 'STARTTIME',
+	                  '-i', 'INPUT', '-f', 'wav',
+			  '-acodec', 'pcm_s16le', '-']),
+
         Decoder('wav', ['cat', 'INPUT']),
         Decoder('opus', ['opusdec', 'INPUT', '--force-wav', '--quiet', '-']),
     ]


### PR DESCRIPTION
I hope I'm going about this the right way as this will be my first ever pull request to a github project.

I ran into the following issue with serving my music library using cherrymusic:  Apple lossless (ALAC) files (.m4a extension) would not play or show any tracks while searching.

After looking into how the audio transcoding works I noticed that ffad appears to be assigned duty on all files ending in .m4a.  Unfortunately it appears that ffad does not handle ALAC while it seems ffmpeg does (at least in my Raspbian/Ubuntu environments.) Since ffmpeg also handles aac as well (on most of the systems I've used) it would seem it could be a drop-in replacement for ffad.  Hopefully, I haven't missed something.  The syntax has been gratuitously copied from the wma ffmpeg declaration.

Thanks again for CherryMusic!