### PR TITLE
Itunes artwork

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
 install:
   - "pip install cherrypy${CHERRYPY_VERSION} --no-use-wheel"
   - "pip install coveralls pyyaml"
-  - "if [[ $TRAVIS_PYTHON_VERSION = 2.6 ]]; then pip install unittest2 --use-mirrors; fi"
+  - "if [[ $TRAVIS_PYTHON_VERSION = 2.6 ]]; then pip install unittest2; fi"
 
 # prepare test run; test local install
 before_script:

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+0.38.0 (unreleased)
+ - IMPROVEMENT: Switch to iTunes API for album art fetching
+ - IMPROVEMENT: Use file metadata when album art fetching
+ - IMPROVEMENT: Better filtering of directory names when fetching album art
+	
 0.37.2 (2016-08-07)
  - FIXED: more fixes for cherrypy detection (thanks Isgar)
 

--- a/cherrymusicserver/albumartfetcher.py
+++ b/cherrymusicserver/albumartfetcher.py
@@ -115,7 +115,7 @@ class AlbumArtFetcher:
             log.e(_(('''unknown album art fetch method: '%(method)s', '''
                      '''using default.''')),
                   {'method': method})
-            method = 'google'
+            method = 'itunes'
         self.method = method
         self.timeout = timeout
 

--- a/cherrymusicserver/albumartfetcher.py
+++ b/cherrymusicserver/albumartfetcher.py
@@ -168,10 +168,6 @@ class AlbumArtFetcher:
             return header, data
         return None, ''
 
-        
-        return None, ''
-
-
     def fetchurls(self, searchterm):
         """fetch image urls based on the provided searchterms
 

--- a/cherrymusicserver/albumartfetcher.py
+++ b/cherrymusicserver/albumartfetcher.py
@@ -80,6 +80,12 @@ class AlbumArtFetcher:
     imageMagickAvailable = programAvailable('convert')
 
     methods = {
+        'itunes': {
+            'url': "http://ax.itunes.apple.com/WebObjects/MZStoreServices.woa/wa/wsSearch?entity=album&term=",
+            'regexes': [
+                'artworkUrl60":"([^"]+)"',
+            ],
+        },
         'amazon': {
             'url': "http://www.amazon.com/s/?field-keywords=",
             'regexes': [
@@ -98,7 +104,7 @@ class AlbumArtFetcher:
         # },
     }
 
-    def __init__(self, method='amazon', timeout=10):
+    def __init__(self, method='itunes', timeout=10):
         """define the urls of the services and a regex to fetch images
         """
         self.MAX_IMAGE_SIZE_BYTES = 100*1024

--- a/cherrymusicserver/albumartfetcher.py
+++ b/cherrymusicserver/albumartfetcher.py
@@ -178,8 +178,6 @@ class AlbumArtFetcher:
         method = self.methods[self.method]
         # use unidecode if it's available
         searchterm = unidecode(searchterm).lower()
-        # make sure the searchterms are only letters, spaces and numbers
-        searchterm = re.sub('[^a-z\s1-9]', ' ', searchterm)
         # the keywords must always be appenable to the method-url
         url = method['url']+urllib.parse.quote(searchterm)
         #download the webpage and decode the data to utf-8

--- a/cherrymusicserver/albumartfetcher.py
+++ b/cherrymusicserver/albumartfetcher.py
@@ -178,8 +178,8 @@ class AlbumArtFetcher:
         method = self.methods[self.method]
         # use unidecode if it's available
         searchterm = unidecode(searchterm).lower()
-        # make sure the searchterms are only letters and spaces
-        searchterm = re.sub('[^a-z\s]', ' ', searchterm)
+        # make sure the searchterms are only letters, spaces and numbers
+        searchterm = re.sub('[^a-z\s1-9]', ' ', searchterm)
         # the keywords must always be appenable to the method-url
         url = method['url']+urllib.parse.quote(searchterm)
         #download the webpage and decode the data to utf-8

--- a/cherrymusicserver/httphandler.py
+++ b/cherrymusicserver/httphandler.py
@@ -445,7 +445,7 @@ class HTTPHandler(object):
                 foldername = os.path.basename(directory)
                 keywords = foldername
                 # remove any odd characters from the folder name
-                keywords = re.sub('[^a-z\s]', ' ', keywords)
+                keywords = re.sub('[^A-Za-z\s]', ' ', keywords)
                 # try metadata from the first file for a more
                 # accurate match
                 files = os.listdir(localpath)

--- a/cherrymusicserver/httphandler.py
+++ b/cherrymusicserver/httphandler.py
@@ -37,6 +37,7 @@ import os  # shouldn't have to list any folder in the future!
 import json
 import cherrypy
 import codecs
+import re
 import sys
 
 try:
@@ -443,6 +444,8 @@ class HTTPHandler(object):
             try:
                 foldername = os.path.basename(directory)
                 keywords = foldername
+                # remove any odd characters from the folder name
+                keywords = re.sub('[^a-z\s]', ' ', keywords)
                 # try metadata from the first file for a more
                 # accurate match
                 files = os.listdir(localpath)
@@ -452,6 +455,7 @@ class HTTPHandler(object):
                     metad = metainfo.getSongInfo(path)
                     if metad.artist and metad.album:
                         keywords = '{} - {}'.format(metad.artist, metad.album)
+
                 log.i(_("Fetching album art for keywords {keywords!r}").format(keywords=keywords))
                 header, data = fetcher.fetch(keywords)
                 if header:

--- a/cherrymusicserver/httphandler.py
+++ b/cherrymusicserver/httphandler.py
@@ -443,6 +443,15 @@ class HTTPHandler(object):
             try:
                 foldername = os.path.basename(directory)
                 keywords = foldername
+                # try metadata from the first file for a more
+                # accurate match
+                files = os.listdir(localpath)
+                if len(files):
+                    fname = files[0]
+                    path = os.path.join(localpath, fname)
+                    metad = metainfo.getSongInfo(path)
+                    if metad.artist and metad.album:
+                        keywords = '{} - {}'.format(metad.artist, metad.album)
                 log.i(_("Fetching album art for keywords {keywords!r}").format(keywords=keywords))
                 header, data = fetcher.fetch(keywords)
                 if header:


### PR DESCRIPTION
This adds a number of album artwork related changes.

1. **Use iTunes API for album artwork**

  The iTunes API gave me better results in my own testing, and also avoids the 'Prime' labels you get all over your artwork when using Amazon.

2. **Use metadata from files when fetching artwork for a directory**

  Previously, the artwork fetcher relied on you having an accurate album name in the containing folder. This often didn't work well for me, as my music was arranged in an Artist / Album structure, meaning that generic album names often resulted in the wrong artist match. This now tries to use the metadata from the first file in a directory to get the correct album and artist names.

3. **Only filter directory names when looking for artwork**

  Previously, the artwork fetcher stripped all numbers from keywords sent to it. This meant that albums or artists with numbers in them frequently returned incorrect or no results. I've moved this filtering to the level above, so that directories have numbers removed (in case you number your directories), but the metadata from change 2) above is used verbatim.