### PR TITLE
Conditional CherryPy latin-1 workaround (httphandler: don't assume filenames are latin-1 when transcoding)

### DIFF
--- a/cherrymusicserver/httphandler.py
+++ b/cherrymusicserver/httphandler.py
@@ -253,8 +253,6 @@ class HTTPHandler(object):
             path = os.path.sep.join(path)
             if sys.version_info < (3, 0):       # workaround for #327 (cherrypy issue)
                 path = path.decode('utf-8')     # make it work with non-ascii
-            else:
-                path = codecs.decode(codecs.encode(path, 'latin1'), 'utf-8')
             fullpath = os.path.join(cherry.config['media.basedir'], path)
 
             starttime = int(params.pop('starttime', 0))


### PR DESCRIPTION
On Linux with python 3 (Arch Linux on 64-bit x86 specifically) I'd get an error like this when I have transcoding enabled and I try to play a file named "01 - 媛星.flac"

```
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/cherrypy/_cprequest.py", line 670, in respond
    response.body = self.handler()
  File "/usr/lib/python3.6/site-packages/cherrypy/lib/encoding.py", line 220, in __call__
    self.body = self.oldhandler(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/cherrypy/_cpdispatch.py", line 60, in __call__
    return self.callable(*self.args, **self.kwargs)
  File "/home/user/cherrymusic.git/cherrymusicserver/httphandler.py", line 257, in trans
    path = codecs.decode(codecs.encode(path, 'latin1'), 'utf-8')
UnicodeEncodeError: 'latin-1' codec can't encode characters in position 23-24: ordinal not in range(256)
```

On Linux at least it's a pretty safe bet that filenames are utf-8.  Even on other operating systems, latin-1 seems like a dangerous thing to assume.  I'm not sure I understand what the intent was, for having latin-1 in here.

With this change, things at least work for me.  It seems safest to make no assumptions at all about encodings in paths, and to treat them just as bytes.