### PR TITLE
Make user session duration configurable

### DIFF
--- a/cherrymusicserver/__init__.py
+++ b/cherrymusicserver/__init__.py
@@ -458,7 +458,7 @@ If you are sure that cherrymusic is not running, you can delete this file and re
             'server.socket_host': socket_host,
             'server.thread_pool': 30,
             'tools.sessions.on': True,
-            'tools.sessions.timeout': 60 * 24,
+            'tools.sessions.timeout': int(config.get('server.session_duration', 60 * 24)),
         })
 
         if not config['server.keep_session_in_ram']:

--- a/cherrymusicserver/configuration.py
+++ b/cherrymusicserver/configuration.py
@@ -222,6 +222,14 @@ def from_defaults():
                     playlists will be lost when the server is restarted.
                             ''')
 
+    with c['server.session_duration'] as session_duration:
+        session_duration.value = 60 * 24
+        # i18n: Don't mind whitespace - string will be re-wrapped automatically. Use blank lines to separate paragraphs.
+        session_duration.doc = _('''
+                    Duration in minutes of the user sessions. Note that this
+                    will not affect auto logged-in users.
+                            ''')
+
     with c['server.ssl_enabled'] as ssl_enabled:
         ssl_enabled.value = False
         # i18n: Don't mind whitespace - string will be re-wrapped automatically. Use blank lines to separate paragraphs.

--- a/doc/man/cherrymusic.conf.5
+++ b/doc/man/cherrymusic.conf.5
@@ -69,6 +69,9 @@ When "permit_remote_admin_login" is set to "False", admin users may only log in 
 .IP "\fB    keep_session_in_ram = True | False\fP"
 If enabled, this option will keep the user sessions in RAM instead of a file in the configuration directory. This means, that any unsaved playlists will be lost when the server is restarted.
 
+.IP "\fB    session_duration = 1440\fP"
+Duration in minutes of the user sessions. Note that this will not affect auto logged-in users.
+
 .IP "\fB    ssl_enabled = True | False\fP"
 This option allows you to use CherryMusic with HTTPS encryption. To enable this option you also have to specify "ssl_port", "ssl_certificate" and "ssl_private_key". If this option is set to "False", all other SSL specific options will be ommited.
 


### PR DESCRIPTION
User session duration was harcoded to 1440 minutes (24h). Now it's
configurable.

This closes issue #667.

Note that I did not find the proper test case to add a unit test. Should I write one?