### PR TITLE
Removed deprecated call to timeout_monitor

### DIFF
--- a/cherrymusicserver/browsersetup.py
+++ b/cherrymusicserver/browsersetup.py
@@ -163,6 +163,5 @@ If you run the server locally, use: localhost:{port}.
 '''.format(port=port)))
 
         cherrypy.lib.caching.expires(0)
-        cherrypy.engine.timeout_monitor.frequency = 1
         cherrypy.engine.start()
         cherrypy.engine.block()


### PR DESCRIPTION
Fixes #704

As stated in the initial issue, [CherryPy v12.0.0][1] removed support for `timeout_monitor`, causing crashes if using a version >=`12.0.0`.  Maybe it's naive of me to think that the problem could be solved just by removing the line, but at the very least it went from unusable to seemingly stable.  That said, I'm not familiar with the codebase yet, so I'd be happy to go for a different solution if someone points out that this is causing behind-the-scenes problems.

[1]: https://github.com/cherrypy/cherrypy/blob/c17be0f9c42bbce95b37688dd548e47114f4a136/CHANGES.rst#v1200 "CherryPy Changelog"