### PR TITLE
Fix cherrypy URL and use HTTPS for twitter

### DIFF
--- a/res/devel.html
+++ b/res/devel.html
@@ -86,10 +86,10 @@
                 <p>Visit the <a href="http://www.fomori.org/cherrymusic">CherryMusic website</a> or get the <a href="http://www.github.com/devsnd/cherrymusic">source-code directly from github</a></p>
                 <p>thanks to</p>
                 <ul>
-                    <li><a href="http://www.cherrypy.org">The CherryPy team</a> for a great application server</li>
+                    <li><a href="https://www.cherrypy.org">The CherryPy team</a> for a great application server</li>
                     <li><a href="http://www.happyworm.com/">HappyWorm</a> for the HTML5 audio playback</li>
                     <li><a href="http://www.komponist-cmb.de">Christian Maximilian Blasius</a> for the idea for the logo!</li>
-                    <li><a href="http://twitter.github.com/bootstrap/">Bootstrap</a> for the nice look'n'feel of the UI</li>
+                    <li><a href="https://twitter.github.com/bootstrap/">Bootstrap</a> for the nice look'n'feel of the UI</li>
                     <li>6arms1leg for maintaining the package for Arch Linux</li>
                     <li>Adrian Sampson for <a href="https://github.com/sampsyo/audioread">audioread</a></li>
                 </ul>

--- a/res/devel.html
+++ b/res/devel.html
@@ -86,7 +86,7 @@
                 <p>Visit the <a href="http://www.fomori.org/cherrymusic">CherryMusic website</a> or get the <a href="http://www.github.com/devsnd/cherrymusic">source-code directly from github</a></p>
                 <p>thanks to</p>
                 <ul>
-                    <li><a href="www.cherrypy.org">The CherryPy team</a> for a great application server</li>
+                    <li><a href="http://www.cherrypy.org">The CherryPy team</a> for a great application server</li>
                     <li><a href="http://www.happyworm.com/">HappyWorm</a> for the HTML5 audio playback</li>
                     <li><a href="http://www.komponist-cmb.de">Christian Maximilian Blasius</a> for the idea for the logo!</li>
                     <li><a href="http://twitter.github.com/bootstrap/">Bootstrap</a> for the nice look'n'feel of the UI</li>


### PR DESCRIPTION
When When clicking the cherrypy.org URL, it routes to `http://CHERRYPY/www.cherrypy.org`. By specifying a protocol, it forces the page to be routed properly.

Also, Use `https` for the url and the Twitter URL for security reasons. I did not change the others because they do not support HTTPS or have valid certificates.