### PR TITLE
Replace storage_type by storage_class in cherrypy config

### DIFF
--- a/cherrymusicserver/__init__.py
+++ b/cherrymusicserver/__init__.py
@@ -458,7 +458,7 @@ If you are sure that cherrymusic is not running, you can delete this file and re
             if not os.path.exists(sessiondir):
                 os.mkdir(sessiondir)
             cherrypy.config.update({
-                'tools.sessions.storage_type': "file",
+                'tools.sessions.storage_class': cherrypy.lib.sessions.FileSession,
                 'tools.sessions.storage_path': sessiondir,
             })
         basedirpath = config['media.basedir']


### PR DESCRIPTION
storage_type should be replaced by storage_class:

https://github.com/cherrypy/cherrypy/issues/1487

It was deprecated in cherrpy v8.1.1 (27 Sep 2016)