### PR TITLE
Fix import error from ABC classes in Python >= 3.10

### DIFF
--- a/cherrymusicserver/configuration.py
+++ b/cherrymusicserver/configuration.py
@@ -38,7 +38,11 @@ import os
 import re
 import weakref
 
-from collections import Mapping, namedtuple
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
+from collections import namedtuple
 from backport.collections import OrderedDict
 from backport import callable
 

--- a/tinytag/tinytag.py
+++ b/tinytag/tinytag.py
@@ -23,7 +23,10 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>
 #
 
-from collections import MutableMapping
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
 import codecs
 from functools import reduce
 import struct


### PR DESCRIPTION
Python 3.10 is out and stable, and is becoming the standard in distros such as Arch. This breaks CherryMusic for die-hard fans, and they're starting to request patches, for example in the [AUR package](https://aur.archlinux.org/packages/cherrymusic) and #732.

I patched away the import errors that were mentioned, and gave the server a quick spin on my Arch box to see what else might be breaking. Everything looked good, at least the core features seem to be fine.

I'm wondering if we could merge this and make a release that would work with Py 3.10 to help out folks who would still like to run CherryMusic today.