### PR TITLE
Python 3.12 compatibility fix

### DIFF
--- a/cherrymusicserver/cherrymodel.py
+++ b/cherrymusicserver/cherrymodel.py
@@ -40,7 +40,7 @@ import codecs
 import json
 import cherrypy
 import audiotranscode
-from imp import reload
+from importlib import reload
 
 try:
     from urllib.parse import quote

--- a/cherrymusicserver/configuration.py
+++ b/cherrymusicserver/configuration.py
@@ -298,7 +298,7 @@ def from_configparser(filepath):
         from backport.configparser import ConfigParser
     cfgp = ConfigParser()
     with open(filepath, encoding='utf-8') as fp:
-        cfgp.readfp(fp)
+        cfgp.read_file(fp)
     dic = OrderedDict()
     for section_name in cfgp.sections():
         if 'DEFAULT' == section_name:

--- a/cherrymusicserver/resultorder.py
+++ b/cherrymusicserver/resultorder.py
@@ -36,7 +36,7 @@ hocuspocus heuristics"""
 from cherrymusicserver import pathprovider
 from cherrymusicserver import log
 import cherrymusicserver.tweak
-from imp import reload
+from importlib import reload
 from cherrymusicserver.util import Performance
 
 class ResultOrder:

--- a/cherrymusicserver/sqlitecache.py
+++ b/cherrymusicserver/sqlitecache.py
@@ -52,7 +52,7 @@ from cherrymusicserver.database.connect import BoundConnector
 from cherrymusicserver.util import Performance
 from cherrymusicserver.progress import ProgressTree, ProgressReporter
 import cherrymusicserver.tweak
-from imp import reload
+from importlib import reload
 import random
 
 from backport import unichr


### PR DESCRIPTION
- Replace `imp` module with `importlib`.
- Replace `ConfigParser.readfp()` with `ConfigParser.read_file()`.