### PR TITLE
Make compatible with Python 3.12

### DIFF
--- a/cherrymusicserver/cherrymodel.py
+++ b/cherrymusicserver/cherrymodel.py
@@ -40,7 +40,11 @@ import codecs
 import json
 import cherrypy
 import audiotranscode
-from imp import reload
+
+try:
+    from imp import reload
+except ModuleNotFoundError:
+    from importlib import reload
 
 try:
     from urllib.parse import quote

--- a/cherrymusicserver/configuration.py
+++ b/cherrymusicserver/configuration.py
@@ -297,8 +297,9 @@ def from_configparser(filepath):
     except ImportError:
         from backport.configparser import ConfigParser
     cfgp = ConfigParser()
+    read_file = cfgp.read_file if hasattr(cfgp, "read_file") else cfgp.readfp
     with open(filepath, encoding='utf-8') as fp:
-        cfgp.readfp(fp)
+        read_file(fp)
     dic = OrderedDict()
     for section_name in cfgp.sections():
         if 'DEFAULT' == section_name:

--- a/cherrymusicserver/resultorder.py
+++ b/cherrymusicserver/resultorder.py
@@ -33,10 +33,14 @@
 fetched from the database by some mystic-voodoo-
 hocuspocus heuristics"""
 
+try:
+    from imp import reload
+except ModuleNotFoundError:
+    from importlib import reload
+
 from cherrymusicserver import pathprovider
 from cherrymusicserver import log
 import cherrymusicserver.tweak
-from imp import reload
 from cherrymusicserver.util import Performance
 
 class ResultOrder:

--- a/cherrymusicserver/sqlitecache.py
+++ b/cherrymusicserver/sqlitecache.py
@@ -42,6 +42,11 @@ from backport.collections import deque, Counter
 from contextlib import closing
 from operator import itemgetter
 
+try:
+    from imp import reload
+except ModuleNotFoundError:
+    from importlib import reload
+
 import cherrymusicserver as cherry
 from cherrymusicserver import database
 from cherrymusicserver import log
@@ -52,7 +57,6 @@ from cherrymusicserver.database.connect import BoundConnector
 from cherrymusicserver.util import Performance
 from cherrymusicserver.progress import ProgressTree, ProgressReporter
 import cherrymusicserver.tweak
-from imp import reload
 import random
 
 from backport import unichr


### PR DESCRIPTION
Keep backward compatibility while dealing with removed symbols, see https://docs.python.org/3/whatsnew/3.12.html#removed

(Similar to #736, but keeps backwards compatibility.)